### PR TITLE
Issue Template Updates for Figma link  #6

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -17,4 +17,4 @@ assignees: ""
 - [Meshery documentation site](https://docs.meshery.io/)
 - [Meshery documentation source](https://github.com/layer5io/meshery/tree/master/docs)
 - [Instructions for contributing to documentation](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
-- 🎨 Wireframes and [ designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)
+- 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,16 +1,20 @@
 ---
 name: 📄 Documentation issue
 about: Issues related to documentation.
-title: '[Docs]'
-labels: 'area/docs'
-assignees: ''
+title: "[Docs]"
+labels: "area/docs"
+assignees: ""
 ---
+
 **Current State:**
 
 **Desired State:**
 
 ---
+
 **Contributor Resources**
+
 - [Meshery documentation site](https://docs.meshery.io/)
 - [Meshery documentation source](https://github.com/layer5io/meshery/tree/master/docs)
 - [Instructions for contributing to documentation](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
+- 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -17,4 +17,4 @@ assignees: ""
 - [Meshery documentation site](https://docs.meshery.io/)
 - [Meshery documentation source](https://github.com/layer5io/meshery/tree/master/docs)
 - [Instructions for contributing to documentation](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
-- 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)
+- 🎨 Wireframes and [ designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -17,5 +17,4 @@ assignees: ""
 - [Meshery documentation site](https://docs.meshery.io/)
 - [Meshery documentation source](https://github.com/layer5io/meshery/tree/master/docs)
 - [Instructions for contributing to documentation](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
-
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -17,4 +17,5 @@ assignees: ""
 - [Meshery documentation site](https://docs.meshery.io/)
 - [Meshery documentation source](https://github.com/layer5io/meshery/tree/master/docs)
 - [Instructions for contributing to documentation](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#documentation-contribution-flow)
+
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)


### PR DESCRIPTION
**Description**
The project's current issue templates are missing an open invitation link where new contributors can join the community's Figma team and view user interface designs and other UX projects.
This PR fixes #6 
invite link added
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
