### PR TITLE
Correct mesheryctl install link

### DIFF
--- a/meshery.sh
+++ b/meshery.sh
@@ -24,7 +24,7 @@ main() {
 	kubectl config view --minify --flatten > ~/minified_config
 	mv ~/minified_config ~/.kube/config
 
-	curl -L https://git.io/meshery | PLATFORM=$meshery_platform bash -
+	curl -L https://meshery.io/install | PLATFORM=$meshery_platform bash -
 
 	sleep 30
 }


### PR DESCRIPTION
**Description**
This PR corrects the meshery install link that causes a 404 error on the bash script

This PR fixes # 

**Notes for Reviewers**
This is a fix in part to for the failing [mesheryctl end to end test](https://github.com/meshery/meshery/actions/workflows/mesheryctl-e2e.yaml)

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
